### PR TITLE
Erinyang/plug

### DIFF
--- a/rpxdock/app/dock.py
+++ b/rpxdock/app/dock.py
@@ -166,8 +166,6 @@ def dock_plug(hscore, **kw):
    else:
       raise ValueError(f'unknown search dock_method {kw.dock_method}')
 
-   logging.info(f'num base samples {sampler.size(0):,}')
-
    plug_bodies = [rp.Body(inp, which_ss="H", **kw) for inp in kw.inputs1]
    hole_bodies = [rp.Body(inp, sym=3, which_ss="H", **kw) for inp in kw.inputs2]
 

--- a/rpxdock/app/dock.py
+++ b/rpxdock/app/dock.py
@@ -166,8 +166,9 @@ def dock_plug(hscore, **kw):
    else:
       raise ValueError(f'unknown search dock_method {kw.dock_method}')
 
-   plug_bodies = [rp.Body(inp, which_ss="H", **kw) for inp in kw.inputs1]
-   hole_bodies = [rp.Body(inp, sym=3, which_ss="H", **kw) for inp in kw.inputs2]
+   plug_bodies = [rp.Body(inp, which_ss="H", allowed_res=allowedres, **kw) for inp, allowedres in zip(kw.inputs1, kw.allowed_residues1)]
+   hole_bodies = [rp.Body(inp, which_ss="H", allowed_res=allowedres, **kw) for inp, allowedres in zip(kw.inputs2, kw.allowed_residues2)]
+
 
    #assert len(bodies) == spec.num_components
 


### PR DESCRIPTION
Adding allowed residues to plug docking 
Got rid of excess logging info in plug docking that was crashing the module (Sorry, copy pasted from multicomp without looking closely)