### PR TITLE
Quintond/score function testing

### DIFF
--- a/rpxdock/app/options.py
+++ b/rpxdock/app/options.py
@@ -202,6 +202,14 @@ def default_cli_parser(parent=None, **kw):
       help='Only for monomer-to-plug docking. score weight of plug / cage hole interface. defaults to 1.0'
    )
    addarg(
+      "--weight_sasa", type=float, default=1500,
+      help="Desired SASA used to weight dock scoring"
+   )
+   addarg(
+      "--weight_error", type=float, default=None,
+      help="Standard deviation used to calculate the distribution of SASA weighting"
+      )
+   addarg(
       "--output_prefix", nargs="?", default="rpxdock", type=str,
       help="output file prefix. will output pickles for a base ResPairScore plus --hierarchy_depth hier XMaps"
    )
@@ -265,7 +273,12 @@ def default_cli_parser(parent=None, **kw):
    addarg("--ignored_aas", default='CGP', help='Amino acids to ignore in scoring')
    addarg("--score_self", action='store_true', default=False,
           help='score each interface seperately and dump in output pickle')
-
+   #addarg("--score_fun", default=standard,
+   #       help='apply this score function to rpx and ncontact')
+   #addarg("--weight_scorefun",
+   #       help='weights to use in score function')
+   addarg("--function", type=str, default='stnd',
+          help='score function to use for scoring')
    parser.has_rpxdock_args = True
    return parser
 

--- a/rpxdock/score/rpxhier.py
+++ b/rpxdock/score/rpxhier.py
@@ -207,8 +207,12 @@ class RpxHier:
          pscore,
       )
       score_functions = {"fun2" : sfx.score_fun2, "lin" : sfx.lin, "exp" : sfx.exp, "mean" : sfx.mean, "median" : sfx.median, "stnd" : sfx.stnd, "sasa_priority" : sfx.sasa_priority}
-      scores = score_functions[kw.function](pos1, pos2, lbub, lbub1, lbub2, ressc1, ressc2, wts=kw.wts)
-
+      score_fx = score_functions.get(kw.function)
+      if score_fx:
+         scores = score_fx(pos1, pos2, lbub, lbub1, lbub2, ressc1, ressc2, wts=kw.wts)
+      else:
+         logging.info(f"Failed to find score function {kw.function}, falling back to 'stnd'")
+         scores = score_functions["stnd"](pos1, pos2, lbub, lbub1, lbub2, ressc1, ressc2, wts=kw.wts)
       return scores
 
    def iresls(self):

--- a/rpxdock/score/rpxhier.py
+++ b/rpxdock/score/rpxhier.py
@@ -1,5 +1,6 @@
 import os, logging, glob, numpy as np, rpxdock as rp
 from rpxdock.xbin import xbin_util as xu
+from rpxdock.score import score_functions as sfx
 
 log = logging.getLogger(__name__)
 
@@ -117,7 +118,7 @@ class RpxHier:
       pos2,
       iresl=-1,
       bounds=(),
-      residue_summary=np.sum,  # TODO hook up to options to select
+      residue_summary=np.mean,  # TODO hook up to options to select
       **kw,
    ):
       '''
@@ -132,7 +133,6 @@ class RpxHier:
       :param kw:
       :return:
       '''
-
       kw = rp.Bunch(kw)
       pos1, pos2 = pos1.reshape(-1, 4, 4), pos2.reshape(-1, 4, 4)
       # if not bounds:
@@ -206,17 +206,8 @@ class RpxHier:
          pairs,
          pscore,
       )
-
-      scores = np.zeros(max(len(pos1), len(pos2)))
-      for i, (lb, ub) in enumerate(lbub):
-         side1 = residue_summary(ressc1[lbub1[i, 0]:lbub1[i, 1]])
-         side2 = residue_summary(ressc2[lbub2[i, 0]:lbub2[i, 1]])
-         # TODO: maybe do this a different way?
-         mscore = side1 + side2
-         # mscore = np.sum(pscore[lb:ub])
-         # mscore = np.log(np.sum(np.exp(pscore[lb:ub])))
-         #TODO generalize scores to specify scoretypes and weights like Rosetta WHS
-         scores[i] = kw.wts.rpx * mscore + kw.wts.ncontact * (ub - lb)
+      score_functions = {"fun2" : sfx.score_fun2, "lin" : sfx.lin, "exp" : sfx.exp, "mean" : sfx.mean, "median" : sfx.median, "stnd" : sfx.stnd, "sasa_priority" : sfx.sasa_priority}
+      scores = score_functions[kw.function](pos1, pos2, lbub, lbub1, lbub2, ressc1, ressc2, wts=kw.wts)
 
       return scores
 

--- a/rpxdock/score/score_functions.py
+++ b/rpxdock/score/score_functions.py
@@ -1,0 +1,111 @@
+import numpy as np
+import rpxdock as rp
+
+def score_fun2(pos1, pos2, lbub, lbub1, lbub2, ressc1, ressc2, **kw):
+   kw = rp.Bunch(kw)
+   scores = np.zeros(max(len(pos1), len(pos2)))
+   for i, (lb, ub) in enumerate(lbub):
+      side1 = np.mean(ressc1[lbub1[i, 0]:lbub1[i, 1]])
+      side2 = np.mean(ressc2[lbub2[i, 0]:lbub2[i, 1]])
+      side1_stdev = np.std(ressc1[lbub1[i, 0]:lbub1[i, 1]])
+      side2_stdev = np.std(ressc2[lbub1[i, 0]:lbub1[i, 1]])
+         # TODO: maybe do this a different way?
+      mscore = (side1 + side2) / 2
+      sscore = np.sqrt(side1_stdev**2 + side2_stdev**2)
+      if np.isnan(sscore):
+         sscore = 100
+
+   #ncont_score = a * np.exp( -((ncont) - b)**2 / (2*c**2) )
+      a=300
+      mu = 75
+      sigma = 50
+      b=np.log(mu**2 / np.sqrt(mu**2 + sigma**2))
+      c=np.log(1 + (sigma**2 / mu**2))
+      #ncont_score = a * np.exp( -((ncont) - mu)**2 / (2*sigma**2) )
+      if (ub - lb) > 0:
+         ncont_score = ( a  / (c * np.sqrt(2 * np.pi) * (ub - lb)) ) * np.exp( -(np.log(ub - lb) - b)**2 / (2*c**2) )
+         scores[i] = kw.wts.rpx * mscore + ncont_score
+      else:
+         scores[i] = 0
+   return scores
+   
+def sasa_priority(pos1, pos2, lbub, lbub1, lbub2, ressc1, ressc2, **kw):
+   kw = rp.Bunch(kw)
+   scores = np.zeros(max(len(pos1), len(pos2)))
+   for i, (lb, ub) in enumerate(lbub):
+      side1 = np.mean(ressc1[lbub1[i, 0]:lbub1[i, 1]])
+      side2 = np.mean(ressc2[lbub2[i, 0]:lbub2[i, 1]])
+      side1_stdev = np.std(ressc1[lbub1[i, 0]:lbub1[i, 1]])
+      side2_stdev = np.std(ressc2[lbub1[i, 0]:lbub1[i, 1]])
+         # TODO: maybe do this a different way?
+      mscore = (side1 + side2) / 2
+      sscore = np.sqrt(side1_stdev**2 + side2_stdev**2)
+      if np.isnan(sscore):
+         sscore = 100
+
+   #ncont_score = a * np.exp( -((ncont) - b)**2 / (2*c**2) )
+      a = kw.wts.ncontact
+      mu = kw.wts.sasa / 21.522
+      if not kw.wts.sasa_error:
+        sigma = mu * 0.2433619617913417
+      else:
+        sigma = kw.wts.sasa_error / 21.522
+      b=np.log(mu**2 / np.sqrt(mu**2 + sigma**2))
+      c=np.log(1 + (sigma**2 / mu**2))
+      #ncont_score = a * np.exp( -((ncont) - mu)**2 / (2*sigma**2) )
+      if (ub - lb) > 0:
+         ncont_score = ( a  / (c * np.sqrt(2 * np.pi) * (ub - lb)) ) * np.exp( -(np.log(ub - lb) - b)**2 / (2*c**2) )
+         scores[i] = kw.wts.rpx * mscore + ncont_score
+      else:
+         scores[i] = 0
+   return scores
+
+def stnd(pos1, pos2, lbub, lbub1, lbub2, ressc1, ressc2, **kw):
+   kw = rp.Bunch(kw)
+   scores = np.zeros(max(len(pos1), len(pos2)))
+   for i, (lb, ub) in enumerate(lbub):
+      side1 = np.sum(ressc1[lbub1[i, 0]:lbub1[i, 1]])
+      side2 = np.sum(ressc2[lbub2[i, 0]:lbub2[i, 1]])
+      mscore = (side1 + side2) / 2
+      scores[i] = kw.wts.rpx * mscore + kw.wts.ncontact * (ub - lb)
+   return scores
+  
+def mean(pos1, pos2, lbub, lbub1, lbub2, ressc1, ressc2, **kw):
+   kw = rp.Bunch(kw)
+   scores = np.zeros(max(len(pos1), len(pos2)))
+   for i, (lb, ub) in enumerate(lbub):
+      side1 = np.mean(ressc1[lbub1[i, 0]:lbub1[i, 1]])
+      side2 = np.mean(ressc2[lbub2[i, 0]:lbub2[i, 1]])
+      mscore = (side1 + side2) / 2
+      scores[i] = kw.wts.rpx * mscore + kw.wts.ncontact * (ub - lb)
+   return scores
+  
+def median(pos1, pos2, lbub, lbub1, lbub2, ressc1, ressc2, **kw):
+   kw = rp.Bunch(kw)
+   scores = np.zeros(max(len(pos1), len(pos2)))
+   for i, (lb, ub) in enumerate(lbub):
+      side1 = np.median(ressc1[lbub1[i, 0]:lbub1[i, 1]])
+      side2 = np.median(ressc2[lbub2[i, 0]:lbub2[i, 1]])
+      mscore = (side1 + side2) / 2
+      scores[i] = kw.wts.rpx * mscore + kw.wts.ncontact * (ub - lb)
+   return scores
+  
+def exp(pos1, pos2, lbub, lbub1, lbub2, ressc1, ressc2, **kw):
+   kw = rp.Bunch(kw)
+   scores = np.zeros(max(len(pos1), len(pos2)))
+   for i, (lb, ub) in enumerate(lbub):
+      side1 = np.sum(ressc1[lbub1[i, 0]:lbub1[i, 1]])
+      side2 = np.sum(ressc2[lbub2[i, 0]:lbub2[i, 1]])
+      mscore = (side1 + side2) / 2
+      scores[i] = mscore - ( 4.6679 * ((ub - lb)**0.588  ))
+   return scores
+  
+def lin(pos1, pos2, lbub, lbub1, lbub2, ressc1, ressc2, **kw):
+   kw = rp.Bunch(kw)
+   scores = np.zeros(max(len(pos1), len(pos2)))
+   for i, (lb, ub) in enumerate(lbub):
+      side1 = np.sum(ressc1[lbub1[i, 0]:lbub1[i, 1]])
+      side2 = np.sum(ressc2[lbub2[i, 0]:lbub2[i, 1]])
+      mscore = (side1 + side2) / 2
+      scores[i] = mscore - ( 0.7514*(ub - lb) )
+   return scores

--- a/rpxdock/search/multicomp.py
+++ b/rpxdock/search/multicomp.py
@@ -127,8 +127,7 @@ class MultiCompEvaluator(MultiCompEvaluatorBase):
          ifscore = list()
          for i in range(len(B)):
             for j in range(i):
-               ifscore.append(self.hscore.scorepos(B[j], B[i], X[ok, j], X[ok, i], iresl,
-                                                   wts=wts))
+               ifscore.append(self.hscore.scorepos(B[j], B[i], X[ok, j], X[ok, i], iresl, function=kw.function, wts=wts))
                # ifscore = np.stack(ifscore)
                logging.debug(f"ifscore is {len(ifscore)} long and is a {type(ifscore)}")
 
@@ -150,10 +149,10 @@ class MultiCompEvaluator(MultiCompEvaluatorBase):
                   logging.debug("found self")
                   Xsym = self.spec.to_neighbor_olig @ X
                   s_ifscore.append(
-                     self.hscore.scorepos(B[j], B[i], X[ok, j], Xsym[ok, i], iresl, wts=wts))
+                     self.hscore.scorepos(B[j], B[i], X[ok, j], Xsym[ok, i], iresl, function=kw.function, wts=wts))
                else:
                   ns_ifscore.append(
-                     self.hscore.scorepos(B[j], B[i], X[ok, j], X[ok, i], iresl, wts=wts))
+                     self.hscore.scorepos(B[j], B[i], X[ok, j], X[ok, i], iresl, function=kw.function, wts=wts))
          logging.debug(f"self scores is length {len(s_ifscore[0])}")
          logging.debug(f"non-self scores is legnth {len(ns_ifscore[0])}")
          logging.debug(f"OK len is {len(ok)}")


### PR DESCRIPTION
This adds a set of score functions in score/score_functions.py that can be used for scoring a dock, specified by the --function flag. The default behaviour is to use the standard score function. The most useful for cage design is sasa_priority. Eventually this should get incorporated into a more general framework for the user to create custom score functions.