### PR TITLE
Quintond/sscount filter

### DIFF
--- a/rpxdock/app/options.py
+++ b/rpxdock/app/options.py
@@ -202,11 +202,11 @@ def default_cli_parser(parent=None, **kw):
       help='Only for monomer-to-plug docking. score weight of plug / cage hole interface. defaults to 1.0'
    )
    addarg(
-      "--weight_sasa", type=float, default=1500,
+      "--weight_sasa", type=float, default=1152,
       help="Desired SASA used to weight dock scoring"
    )
    addarg(
-      "--weight_error", type=float, default=None,
+      "--weight_error", type=float, default=4,
       help="Standard deviation used to calculate the distribution of SASA weighting"
       )
    addarg(

--- a/rpxdock/app/options.py
+++ b/rpxdock/app/options.py
@@ -273,12 +273,28 @@ def default_cli_parser(parent=None, **kw):
    addarg("--ignored_aas", default='CGP', help='Amino acids to ignore in scoring')
    addarg("--score_self", action='store_true', default=False,
           help='score each interface seperately and dump in output pickle')
-   #addarg("--score_fun", default=standard,
-   #       help='apply this score function to rpx and ncontact')
-   #addarg("--weight_scorefun",
-   #       help='weights to use in score function')
    addarg("--function", type=str, default='stnd',
           help='score function to use for scoring')
+   addarg("--sscount_filter", action='store_true', default=False,
+      help='calculate the ss_count in the interface')
+   addarg("--sscount_confidence", action='store_true', default=False,
+      help='If set to 1, docks below the threshold number of ss elements in the interface will not be included in the output')
+   addarg("--sscount_min_helix_length", default=4, type=int,
+      help='Min resis in helix to count as ss element')
+   addarg("--sscount_min_sheet_length", default=3, type=int,
+      help='Min resis in sheet to count as ss element')
+   addarg("--sscount_min_loop_length", default=1, type=int,
+      help='Min resis in loop to count as ss element')
+   addarg("--sscount_max_dist", default=8, type=float,
+      help='Min resis in loop to count as ss element')
+   addarg("--sscount_min_element_resis", default=3, type=int,
+      help='Min interface resis in ss_element to include in ss count')
+   addarg("--sscount_sstype", default="EHL", type=str,
+      help='Types of secondary structure to include in count')
+   addarg("--sscount_min_ss_count", default=3, type=int,
+      help='If confidence set, minimum number of ss elements to pass the filter')
+   addarg("--sscount_strict", action='store_true', default=False,
+      help='Require that both pairs of residues in the interface are in an SS element meeting the set criteria')
    parser.has_rpxdock_args = True
    return parser
 
@@ -312,6 +328,7 @@ def process_cli_args(options, **kw):
    options.iface_summary = _iface_summary_methods[options.iface_summary]
 
    _extract_weights(options)
+   _extract_sscount(options)
 
    set_loglevel(options.loglevel)
 
@@ -492,6 +509,20 @@ def _extract_weights(kw):
    for k in todel:
       del kw[k]
    kw.wts = wts
+
+def _extract_sscount(kw):
+   pref = 'sscount_'
+   ssc = rp.Bunch()
+   todel = list()
+   for k in kw:
+      if k.startswith(pref):
+         ssc_type = k.replace(pref, '')
+         ssc[ssc_type] = kw[k]
+         todel.append(k)
+   for k in todel:
+      del kw[k]
+   kw.ssc = ssc
+
 
 def _process_arg_sspair(kw):
    kw.score_only_sspair = [''.join(sorted(p)) for p in kw.score_only_sspair]

--- a/rpxdock/score/rpxhier.py
+++ b/rpxdock/score/rpxhier.py
@@ -210,8 +210,9 @@ class RpxHier:
       )
       score_functions = {"fun2" : sfx.score_fun2, "lin" : sfx.lin, "exp" : sfx.exp, "mean" : sfx.mean, "median" : sfx.median, "stnd" : sfx.stnd, "sasa_priority" : sfx.sasa_priority}
       score_fx = score_functions.get(self.function)
+
       if score_fx:
-         scores = score_fx(pos1, pos2, lbub, lbub1, lbub2, ressc1, ressc2, wts=kw.wts)
+         scores = score_fx(pos1, pos2, lbub, lbub1, lbub2, ressc1, ressc2, wts=kw.wts, iresl=iresl)
       else:
          logging.info(f"Failed to find score function {self.function}, falling back to 'stnd'")
          scores = score_functions["stnd"](pos1, pos2, lbub, lbub1, lbub2, ressc1, ressc2, wts=kw.wts)

--- a/rpxdock/score/score_functions.py
+++ b/rpxdock/score/score_functions.py
@@ -32,6 +32,35 @@ def score_fun2(pos1, pos2, lbub, lbub1, lbub2, ressc1, ressc2, **kw):
 def sasa_priority(pos1, pos2, lbub, lbub1, lbub2, ressc1, ressc2, **kw):
    kw = rp.Bunch(kw)
    scores = np.zeros(max(len(pos1), len(pos2)))
+
+   #TODO: Quinton: Resolution-dependent scoring is turned off while I try to optimize it further.
+   """
+   if kw.wts.ncontact != 0:
+      if kw.wts.rpx != 0:
+         start_sasa = kw.wts.sasa + ( 576 * 4 )
+         sasa = start_sasa - ( 576 * kw.iresl )
+         if not kw.wts.error:
+            start_error = 6
+         else:
+            start_error = kw.wts.error + 2
+         sigma = start_error - ( kw.iresl / 2 )
+      else:
+         if not kw.wts.error:
+            sigma = 4
+         else:
+            sigma = kw.wts.error
+         sasa = kw.wts.sasa
+   else:
+      if not kw.wts.error:
+          sigma = 4
+      else:
+          sigma = kw.wts.error
+      sasa = kw.wts.sasa
+   """
+   sigma = kw.wts.error
+   sasa = kw.wts.sasa
+   a = kw.wts.ncontact
+
    for i, (lb, ub) in enumerate(lbub):
       if (ub - lb) > 0:
          side1 = np.mean(ressc1[lbub1[i, 0]:lbub1[i, 1]])
@@ -39,19 +68,13 @@ def sasa_priority(pos1, pos2, lbub, lbub1, lbub2, ressc1, ressc2, **kw):
          # TODO: maybe do this a different way?
          mscore = (side1 + side2) / 2
 
-         a = kw.wts.ncontact
-      
-         if not kw.wts.error:
-           sigma = 1
-         else:
-           sigma = kw.wts.error
       
          m = np.exp((-sigma**2.22215285) / 28.59075188)
-         mu = (kw.wts.sasa) / m #convert input sasa (mode) into a mean
+         mu = (sasa) / m #convert input sasa (mode) into a mean
       
          mu = (mu - 14.2198) / 21.522 #redefine mean in terms of ncontact
          sigma = mu * sigma * 0.2433619617913417 #redefine mean in terms of ncontact
-         mode = (kw.wts.sasa - 14.2198) / 21.522 #redefine mode in terms of ncontact
+         mode = (sasa - 14.2198) / 21.522 #redefine mode in terms of ncontact
    
          #calculate parameterization factors
          b=np.log(mu**2 / np.sqrt(mu**2 + sigma**2)) 

--- a/rpxdock/score/score_functions.py
+++ b/rpxdock/score/score_functions.py
@@ -33,17 +33,18 @@ def sasa_priority(pos1, pos2, lbub, lbub1, lbub2, ressc1, ressc2, **kw):
    kw = rp.Bunch(kw)
    scores = np.zeros(max(len(pos1), len(pos2)))
 
-   #TODO: Quinton: Resolution-dependent scoring is turned off while I try to optimize it further.
-   """
+   #TODO: Quinton: Resolution-dependent scoring is turned off while I try to optimize it further. This does nothing right now.
    if kw.wts.ncontact != 0:
       if kw.wts.rpx != 0:
-         start_sasa = kw.wts.sasa + ( 576 * 4 )
-         sasa = start_sasa - ( 576 * kw.iresl )
-         if not kw.wts.error:
-            start_error = 6
-         else:
-            start_error = kw.wts.error + 2
-         sigma = start_error - ( kw.iresl / 2 )
+         #start_sasa = kw.wts.sasa + ( 576 * 4 )
+         #sasa = start_sasa - ( 576 * kw.iresl )
+         sasa = kw.wts.sasa
+         #if not kw.wts.error:
+         #   start_error = 6
+         #else:
+         #   start_error = kw.wts.error + 2
+         #sigma = start_error - ( kw.iresl / 2 )
+         sigma = kw.wts.error
       else:
          if not kw.wts.error:
             sigma = 4
@@ -56,34 +57,32 @@ def sasa_priority(pos1, pos2, lbub, lbub1, lbub2, ressc1, ressc2, **kw):
       else:
           sigma = kw.wts.error
       sasa = kw.wts.sasa
-   """
-   sigma = kw.wts.error
-   sasa = kw.wts.sasa
+  
+   #calculate constants based on weightings
    a = kw.wts.ncontact
+   m = np.exp((-sigma**2.22215285) / 28.59075188)
+   mu = (sasa) / m #convert input sasa (mode) into a mean
+   mu = (mu - 14.2198) / 21.522 #redefine mean in terms of ncontact
+   sigma = mu * sigma * 0.2433619617913417 #redefine mean in terms of ncontact
+   mode = (sasa - 14.2198) / 21.522 #redefine mode in terms of ncontact
 
+   #calculate parameterization factors
+   b=np.log(mu**2 / np.sqrt(mu**2 + sigma**2))
+   c=np.log(1 + (sigma**2 / mu**2))
+
+   #normalization of the lognormal distribution to the maximum score so that all possible sasa/sigma combinations
+   #result in the same maximum possible score
+   prob_max = ( 1  / (c * np.sqrt(2 * np.pi) * (mode)) ) * np.exp( -(np.log(mode) - b)**2 / (2*c**2) )
+
+   #score docks
    for i, (lb, ub) in enumerate(lbub):
       if (ub - lb) > 0:
          side1 = np.mean(ressc1[lbub1[i, 0]:lbub1[i, 1]])
          side2 = np.mean(ressc2[lbub2[i, 0]:lbub2[i, 1]])
          # TODO: maybe do this a different way?
          mscore = (side1 + side2) / 2
-
       
-         m = np.exp((-sigma**2.22215285) / 28.59075188)
-         mu = (sasa) / m #convert input sasa (mode) into a mean
-      
-         mu = (mu - 14.2198) / 21.522 #redefine mean in terms of ncontact
-         sigma = mu * sigma * 0.2433619617913417 #redefine mean in terms of ncontact
-         mode = (sasa - 14.2198) / 21.522 #redefine mode in terms of ncontact
-   
-         #calculate parameterization factors
-         b=np.log(mu**2 / np.sqrt(mu**2 + sigma**2)) 
-         c=np.log(1 + (sigma**2 / mu**2))
-      
-         #ncont_score = a * np.exp( -((ncont) - mu)**2 / (2*sigma**2) )
-         #normalize the lognormal distribution to the maximum score so that all possible sasa/sigma combinations
-         #result in the same maximum possible score
-         prob_max = ( 1  / (c * np.sqrt(2 * np.pi) * (mode)) ) * np.exp( -(np.log(mode) - b)**2 / (2*c**2) )
+         #ncont_score
          ncont_score = ( a / prob_max )*( 1  / (c * np.sqrt(2 * np.pi) * (ub - lb)) ) * np.exp( -(np.log(ub - lb) - b)**2 / (2*c**2) )
          
          scores[i] = kw.wts.rpx * mscore + ncont_score

--- a/rpxdock/search/hierarchical.py
+++ b/rpxdock/search/hierarchical.py
@@ -2,7 +2,7 @@ import logging, itertools, numpy as np, rpxdock as rp
 
 log = logging.getLogger(__name__)
 
-def hier_search(sampler, evaluator, spec, bodies, **kw):
+def hier_search(sampler, evaluator, **kw):
    '''
    :param sampler:
    :param evaluator:
@@ -13,8 +13,12 @@ def hier_search(sampler, evaluator, spec, bodies, **kw):
    kw = rp.Bunch(kw)
    neval, indices, scores = list(), None, None
    nresl = kw.nresl if kw.nresl else evaluator.hscore.actual_nresl
-   iresl_list = []
-   data_list = []
+   
+   #Uncomment to dump docking metrics at each resolution level of the search.
+   #iresl_list = []
+   #data_list = []
+   #spec = kw.spec
+   #bodies = kw.bodies
    for iresl in range(kw.nresl):
       indices, xforms = expand_samples(iresl, sampler, indices, scores, **kw)
       scores, extra, t = rp.search.evaluate_positions(**kw.sub(vars()))

--- a/rpxdock/search/hierarchical.py
+++ b/rpxdock/search/hierarchical.py
@@ -2,7 +2,7 @@ import logging, itertools, numpy as np, rpxdock as rp
 
 log = logging.getLogger(__name__)
 
-def hier_search(sampler, evaluator, **kw):
+def hier_search(sampler, evaluator, spec, bodies, **kw):
    '''
    :param sampler:
    :param evaluator:
@@ -13,13 +13,47 @@ def hier_search(sampler, evaluator, **kw):
    kw = rp.Bunch(kw)
    neval, indices, scores = list(), None, None
    nresl = kw.nresl if kw.nresl else evaluator.hscore.actual_nresl
+   iresl_list = []
+   data_list = []
    for iresl in range(kw.nresl):
       indices, xforms = expand_samples(iresl, sampler, indices, scores, **kw)
       scores, extra, t = rp.search.evaluate_positions(**kw.sub(vars()))
       neval.append((t, len(scores)))
       log.info(f"{kw.output_prefix} iresl {iresl} ntot {len(scores):11,} " +
                f"nonzero {np.sum(scores > 0):5,}")
+   #Uncomment to dump docking metrics at each resolution level of the search. 
+   """
+      iresl_list.append(iresl)
+      wrpx = kw.wts.sub(rpx=1, ncontact=0)
+      wnct = kw.wts.sub(rpx=0, ncontact=1)
+      rpx, rpx_extra = evaluator(xforms, iresl, wrpx)
+      ncontact, ncont_extra = evaluator(xforms, iresl, wnct)
+
+      data = dict(
+         attrs=dict(arg=kw, output_prefix=kw.output_prefix,
+                 output_body='all', sym=spec.arch),
+         scores=(["model"], scores.astype("f4")),
+         xforms=(["model", "comp", "hrow", "hcol"], xforms),
+         rpx=(["model"], rpx),
+         ncontact=(["model"], ncontact),
+      )
+
+      for k, v in extra.items():
+         if not isinstance(v, (list, tuple)) or len(v) > 3:
+            v = ['model'], v
+         data[k] = v
+      for i in range(len(bodies)):
+         data[f'disp{i}'] = (['model'], np.sum(xforms[:, i, :3, 3] * spec.axis[None, i, :3], axis=1))
+         data[f'angle{i}'] = (['model'], rp.homog.angle_of(xforms[:, i]) * 180 / np.pi)
+
+      data_list.append(data)
+
+   search_data = dict(resl = iresl_list, data = data_list)
+   rp.util.dump(search_data, kw.output_prefix + '_iresl_Result.pickle')
+   """
+
    stats = rp.Bunch(ntot=sum(x[1] for x in neval), neval=neval)
+
    return xforms, scores, extra, stats
 
 def expand_samples(iresl, sampler, indices=None, scores=None, beam_size=None, **kw):

--- a/rpxdock/search/multicomp.py
+++ b/rpxdock/search/multicomp.py
@@ -1,5 +1,6 @@
 import itertools, functools, numpy as np, xarray as xr, rpxdock as rp, rpxdock.homog as hm
 from rpxdock.search import hier_search, trim_ok
+from rpxdock.filter import sscount
 import logging
 
 def make_multicomp(
@@ -31,6 +32,22 @@ def make_multicomp(
    xforms, scores, extra, stats = search(sampler, evaluator, **kw)
 
    ibest = rp.filter_redundancy(xforms, bodies, scores, **kw)
+
+   logging.debug(f"Apply sscount filter to docks? {kw.ssc.confidence}")
+   logging.debug(f"Apply sscount filter? {kw.ssc.filter}")
+   if kw.ssc.filter and kw.ssc.confidence:
+      # Apply sscounts filter to docks with confidence 1. Will change dock results.
+      logging.debug("Applying sscount filter to search results")
+      X = xforms.reshape(-1, xforms.shape[-3], 4, 4)
+      B = [b.copy_with_sym(spec.nfold[i], spec.axis[i]) for i, b in enumerate(bodies)]
+      sbest = sscount.filter_sscount(B[0], B[1], X[ibest, 0], X[ibest, 1], min_helix_length=kw.ssc.min_helix_length,
+         min_sheet_length=kw.ssc.min_sheet_length, min_loop_length=kw.ssc.min_loop_length,
+         min_element_resis=kw.ssc.min_element_resis, max_dist=kw.ssc.max_dist,
+         sstype=kw.ssc.sstype, confidence=1, min_ss_count=kw.ssc.min_ss_count, strict=kw.ssc.strict, **kw)
+      # TODO: Add exception handling for empty array sscounts
+      logging.debug(f"Array of docks passingg sscount filter: {sbest}")
+      ibest = ibest[sbest]
+
    tdump = _debug_dump_cage(xforms, bodies, spec, scores, ibest, evaluator, **kw)
 
    if kw.verbose:
@@ -43,6 +60,18 @@ def make_multicomp(
    wnct = kw.wts.sub(rpx=0, ncontact=1)
    rpx, extra = evaluator(xforms, kw.nresl - 1, wrpx)
    ncontact, ncont_extra = evaluator(xforms, kw.nresl - 1, wnct)
+
+   if kw.ssc.filter:
+      # TODO: Edit the filter and this code to handle self-interacting ss_counts
+      X = xforms.reshape(-1, xforms.shape[-3], 4, 4)
+      # scaffold symmetry has to be applied before evaluating ss counts
+      B = [b.copy_with_sym(spec.nfold[i], spec.axis[i]) for i, b in enumerate(bodies)]
+      sscounts_data = sscount.filter_sscount(B[0], B[1], X[:, 0], X[:, 1], min_helix_length=kw.ssc.min_helix_length,
+         min_sheet_length=kw.ssc.min_sheet_length, min_loop_length=kw.ssc.min_loop_length,
+         min_element_resis=kw.ssc.min_element_resis, max_dist=kw.ssc.max_dist,
+         sstype=kw.ssc.sstype, confidence=0, min_ss_count=kw.ssc.min_ss_count, strict=kw.ssc.strict, **kw)
+
+      extra.sscounts = sscounts_data
 
    data = dict(
       attrs=dict(arg=kw, stats=stats, ttotal=t.total, tdump=tdump, output_prefix=kw.output_prefix,

--- a/rpxdock/search/multicomp.py
+++ b/rpxdock/search/multicomp.py
@@ -29,7 +29,8 @@ def make_multicomp(
    evaluator = Evaluator(bodies, spec, hscore, **kw)
 
    # do search
-   xforms, scores, extra, stats = search(sampler, evaluator, spec, bodies, **kw)
+   #TODO: Quinton: spec and bodies are added to test resolution level score function weighting
+   xforms, scores, extra, stats = search(sampler, evaluator, spec=spec, bodies=bodies, **kw)
 
    ibest = rp.filter_redundancy(xforms, bodies, scores, **kw)
 

--- a/rpxdock/search/multicomp.py
+++ b/rpxdock/search/multicomp.py
@@ -29,7 +29,7 @@ def make_multicomp(
    evaluator = Evaluator(bodies, spec, hscore, **kw)
 
    # do search
-   xforms, scores, extra, stats = search(sampler, evaluator, **kw)
+   xforms, scores, extra, stats = search(sampler, evaluator, spec, bodies, **kw)
 
    ibest = rp.filter_redundancy(xforms, bodies, scores, **kw)
 


### PR DESCRIPTION
I created an ss_count filter that should behave similarly to the filter in Rosetta. By default it adds a column to the data with the filter value. Setting the confidence has the same effect as Rosetta. There is also a simple flag that, when set to false, will dump a more detailed description of the sscount data in the result. What is considered contributing to an SS element can be adjusted as well.

I also have code in here for search resolution dependent filtering but it is completely commented out right now so it will not have any impact on the result. I have it in there to test interactions with the sscount filter. At some point I will submit a pull request to activate that functionality.